### PR TITLE
fix: default route after register and login

### DIFF
--- a/app/Providers/RouteServiceProvider.php
+++ b/app/Providers/RouteServiceProvider.php
@@ -17,7 +17,7 @@ class RouteServiceProvider extends ServiceProvider
      *
      * @var string
      */
-    public const HOME = '/dashboard';
+    public const HOME = '/home';
 
     /**
      * Define your route model bindings, pattern filters, and other route configuration.

--- a/routes/web.php
+++ b/routes/web.php
@@ -21,8 +21,6 @@ Route::get('/', function () {
 })->name('home');
 
 
-Route::redirect('/dashboard', '/home')->middleware(['auth', 'verified'])->name('loggedIn');
-
 Route::get('/home', function () {
     return view('home');
 })->middleware(['auth', 'verified'])->name('loggedIn');


### PR DESCRIPTION
After registration and login, user will be redirected to /home route instead of /dashboard